### PR TITLE
German-language journal citation conventions

### DIFF
--- a/lib/anystyle/feature/keyword.rb
+++ b/lib/anystyle/feature/keyword.rb
@@ -33,7 +33,7 @@ module AnyStyle
             :etal
           when /^(pp?|pages?|S(eiten?)?|ff?)$/
             :page
-          when /^(vol(ume)?s?|iss(ue)?|n[or]?|number|fasc(icle|icule)?|suppl(ement)?)$/i
+          when /^(vol(ume)?s?|iss(ue)?|n[or]?|number|fasc(icle|icule)?|suppl(ement)|j(ahrgan)g|heft?)$/i
             :volume
           when /^(ser(ies?)?|reihe|[ck]oll(e[ck]tion))$/i
             :series
@@ -56,7 +56,7 @@ module AnyStyle
             :pubmed
           when /^(arxiv)/i
             :arxiv
-          when /^(retrieved|retirado|accessed)$/i
+          when /^(retrieved|retirado|accessed|ab(ruf|gerufen))$/i
             :accessed
           when /^[ILXVMCD]{2,}$/
             :roman

--- a/lib/anystyle/normalizer/volume.rb
+++ b/lib/anystyle/normalizer/volume.rb
@@ -3,35 +3,38 @@ module AnyStyle
     class Volume < Normalizer
       @keys = [:volume, :pages, :date]
 
+      VOLNUM_RX = '(\p{Lu}?\d+|[IVXLCDM]+)'
       def normalize(item, **opts)
         map_values(item, [:volume]) do |_, volume|
           volume = StringUtils.strip_html volume
 
           unless item.key?(:date)
-            unless volume.sub!(/([12]\d{3});|\(([12]\d{3})\)/, '').nil?
-              append item, :date, $1 || $2
+            unless volume.sub!(/([12]\d{3});|\(([12]\d{3})\)|\/([12]\d{3})/, '').nil?
+              append item, :date, $1 || $2 || $3
             end
           end
 
           case volume
-          when /(?:^|\s)(\p{Lu}?\d+|[IVXLCDM]+)\s?\(([^)]+)\)(\s?\d+\p{Pd}\d+)?/
+          when /(?:^|\s)#{VOLNUM_RX}\s?\(([^)]+)\)(\s?\d+\p{Pd}\d+)?/
             volume = $1
             append item, :issue, $2
             append item, :pages, $3.strip unless $3.nil?
             volume
-          when /(?:(\p{Lu}?\d+|[IVXLCDM]+)[\p{P}\s]+)?(?:nos?|nr|n°|nº|iss?|fasc)\.?\s?(.+)$/i
+          when /(?:#{VOLNUM_RX}
+                (?:\.?\s*J(?:ahrgan)?g\.?)?
+                [\p{P}\s]+)?(?:nos?|nr|n°|nº|iss?|fasc|heft|h)\.?\s?(.+)$/ix
             volume = $1
             append item, :issue, $2.sub(/\p{P}$/, '')
             volume
-          when /(\p{Lu}?\d+|[IVXLCDM]+):(\d+(\p{Pd}\d+)?)/
+          when /#{VOLNUM_RX}:(\d+(\p{Pd}\d+)?)/
             volume = $1
             append item, (($3.nil? || item.key?(:pages)) ? :issue : :pages), $2
             volume
-          when /(\p{Lu}?\d+|[IVXLCDM]+)[\.\/](\S+)/
+          when /#{VOLNUM_RX}[\.\/](\S+)/
             volume = $1
             append item, :issue, $2.sub(/\p{P}$/, '')
             volume
-          when /(\d+) [Vv]ol/
+          when /(\d+) [Vv]ol/, /J(?:ahrgan)?g\.? (\d+)/
             $1
           else
             volume

--- a/res/parser/core.xml
+++ b/res/parser/core.xml
@@ -11372,4 +11372,24 @@
     <publisher>NHTSA,</publisher>
     <date>July 2007.</date>
   </sequence>
+  <sequence>
+	<author>Reinermann, H.:</author>
+	<title>Der Offentliche Sektor als Transformator in der Netzwerkgesellschaft.</title>
+	<journal>In: Verwaltung und Management.</journal>
+	<volume>10. Jg.</volume>
+	<date>(2004),</date>
+	<volume>Heft 4,</volume>
+	<pages>S. 192-195.</pages>
+	<url>URL: http://www.dhv-speyer.de/rei/PUBLICA/online/cisco.pdf</url>
+	<note>Abruf am: 17.03.2005</note>
+  </sequence>
+  <sequence>
+    <author>Schöler, Jutta:</author>
+    <title>Leistungsförderung und Gewaltprävention – Grundlagen integrativer Erziehung.</title>
+    <journal>In: Bayerisches Integrationsinfo</journal>
+    <volume>5.Jg/Heft 3,</volume>
+    <date>1998,</date>
+    <pages>S.10 – 19</pages>
+    <note>(auch als Volltext abrufbar über www.bidok.uibk.ac.at/)</note>
+  </sequence>
 </dataset>

--- a/res/parser/gold.xml
+++ b/res/parser/gold.xml
@@ -13308,4 +13308,12 @@
     <journal>Water Resour Res</journal>
     <volume>37(1):109-117 .</volume>
   </sequence>
+  <sequence>
+    <author>Irmtraud Schnell:</author>
+    <date>2014</date>
+    <title>Dank an Hubert Hüppe.</title>
+    <journal>Zeitschrift für Inklusion. Gemeinsam leben.</journal>
+    <volume>22. Jg. Heft 3,</volume>
+    <pages>143 f.</pages>
+  </sequence>
 </dataset>

--- a/spec/anystyle/normalizer/volume_spec.rb
+++ b/spec/anystyle/normalizer/volume_spec.rb
@@ -44,14 +44,19 @@ module AnyStyle
         'Vol. LXVI(6),' => { volume: ['LXVI'], issue: ['6'] },
         'vol. XXXI, nº 2,' => { volume: ['XXXI'], issue: ['2'] },
         'XXXVI/1-2,' => { volume: ['XXXVI'], issue: ['1-2'] },
-        'vol. CLXXXIII, fasc. 603,' => { volume: ['CLXXXIII'], issue: ['603'] }
+        'vol. CLXXXIII, fasc. 603,' => { volume: ['CLXXXIII'], issue: ['603'] },
+        '22. Jg. Heft 3,' => { volume: ['22'], issue: ['3'] },
+        '19.Jg. H.3,' => { volume: ['19'], issue: ['3'] },
+        'Jg. 37:' => { volume: ['37'] }
+        
         # 47ème année, n°1,
         # Isuue 140,
         # 40 (4), art. no. 5446343,
         # 129, 4, Pt. 2:
 
       }).each do |(a, b)|
-        expect(n.normalize(volume: [a])).to include(b)
+        expect(n.normalize(volume: [a])).to include(b),
+                                            -> { "'#{a}' should normalise to #{b}, got: " + n.normalize(volume: [a]).to_s }
       end
     end
 
@@ -63,8 +68,11 @@ module AnyStyle
       ({
         '17(1)73-84.' => { volume: ['17'], issue: ['1'], pages: ['73-84'] },
         '51:197-204' => { volume: ['51'], pages: ['197-204'] }
+        # '22(3):pp.87-106' => { volume: ['22'], issue: ['3'], pages: ['87-106'] },
+        # '35:S42-S45' => { volume: ['35'], pages: ['42-45'] }
       }).each do |(a, b)|
-        expect(n.normalize(volume: [a])).to include(b)
+        expect(n.normalize(volume: [a])).to include(b),
+                                            ->{ "'#{a}' should normalise to #{b}, got: " + n.normalize(volume: [a]).to_s }
       end
     end
 
@@ -75,9 +83,12 @@ module AnyStyle
           '2008;2(3):' => { volume: ['2'], issue: ['3'], date: ['2008'] },
           '2009;22' => { volume: ['22'], date: ['2009'] },
           '321(9859)' => { volume: ['321'], issue: ['9859'] },
-          '494-495(2014):' => { volume: ['494-495'], date: ['2014'] }
+          '494-495(2014):' => { volume: ['494-495'], date: ['2014'] },
+          '19 Jg., Heft 2/2011,' => { volume: ['19'], issue: ['2'], date: ['2011'] },
+          'Jg. 51, Heft 3/2000,' => { volume: ['51'], issue: ['3'], date: ['2000'] }
         }).each do |(a, b)|
-          expect(n.normalize(volume: [a])).to include(b)
+          expect(n.normalize(volume: [a])).to include(b),
+                                              ->{ "'#{a}' should normalise to #{b}, got: " + n.normalize(volume: [a]).to_s }
         end
       end
     end


### PR DESCRIPTION
Improved support for labelling and correctly normalising German conventions with "Jahrgang" (volume) and "Heft" (issue)

Addresses https://github.com/inukshuk/anystyle/issues/117