### PR TITLE
Fix optional parts of volume keywords

### DIFF
--- a/lib/anystyle/feature/keyword.rb
+++ b/lib/anystyle/feature/keyword.rb
@@ -33,7 +33,7 @@ module AnyStyle
             :etal
           when /^(pp?|pages?|S(eiten?)?|ff?)$/
             :page
-          when /^(vol(ume)?s?|iss(ue)?|n[or]?|number|fasc(icle|icule)?|suppl(ement)|j(ahrgan)g|heft?)$/i
+          when /^(vol(ume)?s?|iss(ue)?|n[or]?|number|fasc(icle|icule)?|suppl(ement)?|j(ahrgan)?g|heft)$/i
             :volume
           when /^(ser(ies?)?|reihe|[ck]oll(e[ck]tion))$/i
             :series


### PR DESCRIPTION
I don't know whether `heft` should be `heft?` but it looks to me the `|j(ahrgan)g|heft` was simply inserted *before* `suppl(ement)`s `?` instead of after in the previous patch.

See a489c56092cf9ebe757be8b6fe5e9e85a73c09ed