### PR TITLE
Check that dictionary can be written to the location

### DIFF
--- a/lib/anystyle/dictionary/marshal.rb
+++ b/lib/anystyle/dictionary/marshal.rb
@@ -19,7 +19,9 @@ module AnyStyle
       ensure
         if empty?
           populate!
-          ::Marshal.dump(db, File.open(options[:path], 'wb'))
+          if File.writable?(options[:path])
+            ::Marshal.dump(db, File.open(options[:path], 'wb'))
+          end
         end
       end
     end


### PR DESCRIPTION
It is possible that the current user does not have permission to write
to the chosen file location for marshalling the dictionary. If so, don't
try.