### PR TITLE
Compatibility with Ruby 3.2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,14 +90,14 @@ task :check, :model do |t, args|
     Dir['./res/finder/*.ttx'].sort.each do |ttx|
       print 'Checking %.25s' % "#{File.basename(ttx)}....................."
       start = Time.now
-      stats = AnyStyle.finder.check ttx.untaint
+      stats = AnyStyle.finder.check ttx
       report stats, Time.now - start
     end
   else
     Dir['./res/parser/*.xml'].sort.each do |xml|
       print 'Checking %.25s' % "#{File.basename(xml)}....................."
       start = Time.now
-      stats = AnyStyle.parser.check xml.untaint
+      stats = AnyStyle.parser.check xml
       report stats, Time.now - start
     end
   end
@@ -106,11 +106,11 @@ end
 desc "Save delta of a tagged dataset with itself"
 task :delta, :input do |t, args|
   require 'anystyle'
-  input = args[:input].untaint
+  input = args[:input]
   if File.directory?(input)
     files = Dir.entries(input)
       .reject { |f| f.start_with?('.') }
-      .map { |f| File.join(input, f).untaint }
+      .map { |f| File.join(input, f) }
   else
     files = [input]
   end
@@ -141,7 +141,7 @@ end
 desc "Find references in document"
 task :find, :input do |t, args|
   require 'anystyle'
-  file = args[:input].untaint
+  file = args[:input]
   refs = AnyStyle.finder.find(file, format: :references)[0]
   break unless refs.length > 0
   output = AnyStyle.parser.label refs.join("\n")

--- a/anystyle.gemspec
+++ b/anystyle.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_runtime_dependency('bibtex-ruby', '~>6.0')
-  s.add_runtime_dependency('anystyle-data', '~>1.2')
-  s.add_runtime_dependency('wapiti', '~>2.0')
+  s.add_runtime_dependency('anystyle-data', '~>1.3')
+  s.add_runtime_dependency('wapiti', '~>2.1')
   s.add_runtime_dependency('namae', '~>1.0')
 
   s.files =

--- a/lib/anystyle/dictionary/marshal.rb
+++ b/lib/anystyle/dictionary/marshal.rb
@@ -10,7 +10,7 @@ module AnyStyle
       end
 
       def open
-        if File.exists?(options[:path])
+        if File.exist?(options[:path])
           @db = ::Marshal.load(File.open(options[:path]))
         else
           @db = {}

--- a/lib/anystyle/document.rb
+++ b/lib/anystyle/document.rb
@@ -19,8 +19,6 @@ module AnyStyle
 
       def open(path, format: File.extname(path), tagged: false, **opts)
         raise ArgumentError,
-          "cannot open tainted path: '#{path}'" if path.tainted?
-        raise ArgumentError,
           "document not found: '#{path}'" unless File.exist?(path)
 
         path = File.absolute_path(path)

--- a/lib/anystyle/finder.rb
+++ b/lib/anystyle/finder.rb
@@ -8,7 +8,7 @@ module AnyStyle
       compact: true,
       threads: 4,
       format: :references,
-      training_data: Dir[File.join(RES, 'finder', '*.ttx')].map(&:untaint),
+      training_data: Dir[File.join(RES, 'finder', '*.ttx')],
       layout: true,
       pdftotext: 'pdftotext',
       pdfinfo: 'pdfinfo'

--- a/lib/anystyle/parser.rb
+++ b/lib/anystyle/parser.rb
@@ -87,7 +87,7 @@ module AnyStyle
       when Wapiti::Sequence
         expand Wapiti::Dataset.new([input])
       when String
-        if !input.tainted? && input.length < 1024 && File.exists?(input)
+        if input.length < 1024 && File.exists?(input)
           expand Wapiti::Dataset.open(input, **opts)
         else
           expand Wapiti::Dataset.parse(input, **opts)

--- a/lib/anystyle/parser.rb
+++ b/lib/anystyle/parser.rb
@@ -87,7 +87,7 @@ module AnyStyle
       when Wapiti::Sequence
         expand Wapiti::Dataset.new([input])
       when String
-        if input.length < 1024 && File.exists?(input)
+        if input.length < 1024 && File.exist?(input)
           expand Wapiti::Dataset.open(input, **opts)
         else
           expand Wapiti::Dataset.parse(input, **opts)

--- a/lib/anystyle/support.rb
+++ b/lib/anystyle/support.rb
@@ -1,4 +1,4 @@
 module AnyStyle
-  SUPPORT = File.expand_path('../support', __FILE__).untaint
-  RES = File.expand_path('../../../res', __FILE__).untaint
+  SUPPORT = File.expand_path('../support', __FILE__)
+  RES = File.expand_path('../../../res', __FILE__)
 end

--- a/lib/anystyle/utils.rb
+++ b/lib/anystyle/utils.rb
@@ -63,21 +63,18 @@ module AnyStyle
     module_function
 
     def pdf_to_text(path, pdftotext: 'pdftotext', **opts)
-      raise "pdftotext is tainted" if pdftotext.tainted?
       text = %x{#{pdftotext} #{pdf_opts(path, **opts).join(' ')} "#{path}" -}
       raise "pdftotext failed with error code #{$?.exitstatus}" unless $?.success?
       text.force_encoding(opts[:encoding] || 'UTF-8')
     end
 
     def pdf_info(path, pdfinfo: 'pdfinfo', **opts)
-      raise "pdfinfo is tainted" if pdfinfo.tainted?
       Hash[%x{#{pdfinfo} "#{path}"}.split("\n").map { |ln|
         ln.split(/:\s+/, 2)
       }]
     end
 
     def pdf_info(path, pdfinfo: 'pdfinfo', **opts)
-      raise "pdfinfo is tainted" if pdfinfo.tainted?
       %x{#{pdfinfo} -meta "#{path}"}
     end
 

--- a/spec/anystyle/dictionary/gdbm_spec.rb
+++ b/spec/anystyle/dictionary/gdbm_spec.rb
@@ -27,7 +27,7 @@ begin
 
       it "can be opened" do
         expect { dict.open }.to change { dict.open? }
-        expect(File.exists?(dict.options[:path])).to be true
+        expect(File.exist?(dict.options[:path])).to be true
       end
     end
   end

--- a/spec/find.rb
+++ b/spec/find.rb
@@ -11,12 +11,12 @@ $:.unshift(File.join(File.dirname(__FILE__), '../lib'))
 require 'anystyle'
 
 src = ARGV[0]
-dst = "#{(ARGV[1] || '.')}".untaint
+dst = "#{(ARGV[1] || '.')}"
 
 if File.directory?(src)
-  src = Dir["#{src}/*.{txt,ttx,pdf}"].map(&:untaint)
+  src = Dir["#{src}/*.{txt,ttx,pdf}"]
 else
-  src = [src.dup.untaint]
+  src = [src.dup]
 end
 
 src.each do |input|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require 'yaml'
 AnyStyle::Dictionary.defaults[:adapter] = :memory
 
 module Fixtures
-  PATH = File.expand_path('../fixtures', __FILE__).untaint
+  PATH = File.expand_path('../fixtures', __FILE__)
 
 	Dir[File.join(PATH, '*.rb')].each do |fixture|
 		require fixture
@@ -53,7 +53,7 @@ module Fixtures
 end
 
 module Resources
-  PATH = File.expand_path('../../res', __FILE__).untaint
+  PATH = File.expand_path('../../res', __FILE__)
 
   def resource(name = 'parser/core.xml', format: 'hash', **opts)
     AnyStyle::Parser.new.parse File.join(PATH, name), format: format, **opts


### PR DESCRIPTION
I've updated `File.exists?` to `File.exist?` [to fix the NoMethodError error in Ruby 3.2.0](https://bugs.ruby-lang.org/issues/17391).

And just like with its updated deps, this change removes taint checking, which has been deprecated since Ruby 2.7 and has no effect.

See this thread for more info and links to similar gems with c extensions having taint checking
removed: https://bugs.ruby-lang.org/issues/16131#note-24

_This change accompanies the PR made to `wapiti` in https://github.com/inukshuk/wapiti-ruby/pull/9 and `anystyle-data` in https://github.com/inukshuk/anystyle-data/pull/2. It is required to be able to make the `anystyle-cli` gem compatible with the latest Ruby version. PR coming up after this is released._