### PR TITLE
Adding RIS as a possible output format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
-
-gem 'anystyle-cli', git: 'https://github.com/ColourBlindHobbiest/anystyle-cli.git'
-
 gemspec
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+
+gem 'anystyle-cli', git: 'https://github.com/ColourBlindHobbiest/anystyle-cli.git'
+
 gemspec
 
 group :development, :test do

--- a/lib/anystyle.rb
+++ b/lib/anystyle.rb
@@ -49,6 +49,7 @@ require 'anystyle/normalizer/volume'
 
 require 'anystyle/format/bibtex'
 require 'anystyle/format/csl'
+require 'anystyle/format/ris'
 
 require 'anystyle/page'
 require 'anystyle/refs'

--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -12,31 +12,44 @@ module AnyStyle
         lines << "TY  - #{type}"
 
         add_authors(lines, entry[:author])
-        lines << "PY  - #{entry[:issued]}" if entry[:issued]
-        lines << "TI  - #{entry[:title]}" if entry[:title]
-        lines << "T2  - #{entry[:'container-title']}" if entry[:'container-title']
-        lines << "PB  - #{entry[:publisher]}" if entry[:publisher]
-        lines << "SN  - #{entry[:ISBN] || entry[:ISSN]}" if entry[:ISBN] || entry[:ISSN]
-        lines << "DO  - #{entry[:DOI]}" if entry[:DOI]
-        lines << "UR  - #{entry[:URL]}" if entry[:URL]
-        lines << "ET  - #{entry[:edition]}" if entry[:edition]
-        lines << "CY  - #{entry[:'publisher-place'] || entry[:location]}" if entry[:'publisher-place'] || entry[:location]
-        lines << "VL  - #{entry[:volume]}" if entry[:volume]
-        lines << "IS  - #{entry[:issue]}" if entry[:issue]
-        lines << "SP  - #{entry[:page].to_s.split('-')[0]}" if entry[:page]
-        lines << "EP  - #{entry[:page].to_s.split('-')[1]}" if entry[:page]&.include?("-")
+        lines << "PY  - #{unwrap(entry[:issued])}" if entry[:issued]
+        lines << "TI  - #{unwrap(entry[:title])}" if entry[:title]
+        lines << "T2  - #{unwrap(entry[:'container-title'])}" if entry[:'container-title']
+        lines << "PB  - #{unwrap(entry[:publisher])}" if entry[:publisher]
+        lines << "SN  - #{unwrap(entry[:ISBN] || entry[:ISSN])}" if entry[:ISBN] || entry[:ISSN]
+        lines << "DO  - #{unwrap(entry[:DOI])}" if entry[:DOI]
+        lines << "UR  - #{unwrap(entry[:URL])}" if entry[:URL]
+        lines << "ET  - #{unwrap(entry[:edition])}" if entry[:edition]
+        lines << "CY  - #{unwrap(entry[:'publisher-place'] || entry[:location])}" if entry[:'publisher-place'] || entry[:location]
+        lines << "VL  - #{unwrap(entry[:volume])}" if entry[:volume]
+        lines << "IS  - #{unwrap(entry[:issue])}" if entry[:issue]
+        lines << "SP  - #{unwrap(entry[:page].to_s.split('-')[0])}" if entry[:page]
+        lines << "EP  - #{unwrap(entry[:page].to_s.split('-')[1])}" if entry[:page]&.include?("-")
         lines << "ER  -"
 
         lines.join("\n")
       end
 
+      # Extended RIS type mapping
       def ris_type(type)
-        case type
-        when 'book' then 'BOOK'
-        when 'chapter' then 'CHAP'
-        when 'article-journal' then 'JOUR'
-        else 'GEN' # Generic
+        case type.to_s.downcase
+        when 'book'            then 'BOOK'  # Book
+        when 'chapter'         then 'CHAP'  # Book chapter
+        when 'article-journal' then 'JOUR'  # Journal article
+        when 'magazine-article', 'magazine' then 'MGZN'  # Magazine
+        when 'newspaper-article', 'news'    then 'NEWS'  # Newspaper
+        when 'conference-paper', 'proceedings-article' then 'CONF'  # Conference
+        when 'manuscript'      then 'UNPB'  # Unpublished
+        when 'thesis'          then 'THES'  # Thesis/dissertation
+        when 'webpage', 'electronic', 'online' then 'ELEC'  # Electronic source
+        when 'film'            then 'MPCT'  # Motion picture
+        when 'report'          then 'RPRT'  # Technical report
+        else 'GEN' # Generic fallback
         end
+      end
+
+      def unwrap(val)
+        val.is_a?(Array) ? val.first : val
       end
 
       def add_authors(lines, authors)
@@ -44,12 +57,19 @@ module AnyStyle
 
         authors.each do |author|
           name = if author[:literal]
-                   author[:literal]
-                 elsif author[:family] || author[:given]
-                   [author[:family], author[:given]].compact.join(', ')
-                 else
-                   nil
-                 end
+                  author[:literal]
+                elsif author[:family] || author[:given]
+                  family = author[:family]
+                  given = author[:given]&.gsub('.', '')
+
+                  # Add space between adjacent uppercase initials (e.g., "HJ" => "H J")
+                  given = given.gsub(/(?<=\A|\s)([A-Z])(?=[A-Z])/, '\1 ') if given
+
+                  [family, given].compact.join(', ')
+                else
+                  nil
+                end
+
           lines << "AU  - #{name}" if name
         end
       end

--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -1,0 +1,58 @@
+module AnyStyle
+  module Format
+    module RIS
+      def format_ris(dataset, **opts)
+        format_hash(dataset).map { |entry| format_entry(entry) }.join("\n\n") + "\n"
+      end
+
+      def format_entry(entry)
+        lines = []
+
+        type = ris_type(entry[:type])
+        lines << "TY  - #{type}"
+
+        add_authors(lines, entry[:author])
+        lines << "PY  - #{entry[:issued]}" if entry[:issued]
+        lines << "TI  - #{entry[:title]}" if entry[:title]
+        lines << "T2  - #{entry[:'container-title']}" if entry[:'container-title']
+        lines << "PB  - #{entry[:publisher]}" if entry[:publisher]
+        lines << "SN  - #{entry[:ISBN] || entry[:ISSN]}" if entry[:ISBN] || entry[:ISSN]
+        lines << "DO  - #{entry[:DOI]}" if entry[:DOI]
+        lines << "UR  - #{entry[:URL]}" if entry[:URL]
+        lines << "ET  - #{entry[:edition]}" if entry[:edition]
+        lines << "CY  - #{entry[:'publisher-place'] || entry[:location]}" if entry[:'publisher-place'] || entry[:location]
+        lines << "VL  - #{entry[:volume]}" if entry[:volume]
+        lines << "IS  - #{entry[:issue]}" if entry[:issue]
+        lines << "SP  - #{entry[:page].to_s.split('-')[0]}" if entry[:page]
+        lines << "EP  - #{entry[:page].to_s.split('-')[1]}" if entry[:page]&.include?("-")
+        lines << "ER  -"
+
+        lines.join("\n")
+      end
+
+      def ris_type(type)
+        case type
+        when 'book' then 'BOOK'
+        when 'chapter' then 'CHAP'
+        when 'article-journal' then 'JOUR'
+        else 'GEN' # Generic
+        end
+      end
+
+      def add_authors(lines, authors)
+        return unless authors
+
+        authors.each do |author|
+          name = if author[:literal]
+                   author[:literal]
+                 elsif author[:family] || author[:given]
+                   [author[:family], author[:given]].compact.join(', ')
+                 else
+                   nil
+                 end
+          lines << "AU  - #{name}" if name
+        end
+      end
+    end
+  end
+end

--- a/lib/anystyle/parser.rb
+++ b/lib/anystyle/parser.rb
@@ -96,8 +96,9 @@ module AnyStyle
   class Parser < ParserCore
     include Format::BibTeX
     include Format::CSL
+    include Format::RIS
 
-    @formats = [:bibtex, :citeproc, :csl, :hash, :wapiti]
+    @formats = [:bibtex, :citeproc, :csl, :hash, :wapiti, :ris]
 
     @defaults = {
       model: File.join(SUPPORT, 'parser.mod'),
@@ -190,7 +191,7 @@ module AnyStyle
       case format.to_sym
       when :wapiti
         label(input, **opts)
-      when :hash, :bibtex, :citeproc, :csl
+      when :hash, :bibtex, :citeproc, :csl, :ris
         formatter = "format_#{format}".to_sym
         send(formatter, label(input, **opts), **opts)
       else

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require_relative '../../../lib/anystyle/format/ris'
+
+describe AnyStyle::Format::RIS do
+  include AnyStyle::Format::RIS
+
+  # Mock of the format_hash method
+  def format_hash(dataset)
+    dataset
+  end
+
+  it 'formats a book reference in RIS format' do
+    data = [{
+      type: 'book',
+      author: [{ family: 'Lingard', given: 'Zac' }],
+      issued: '2023',
+      title: 'The Great Emu War',
+      publisher: 'Wiley',
+      ISBN: '9780245839459',
+      URL: 'https://example.com',
+      edition: '1',
+      'publisher-place': 'New York'
+    }]
+
+    output = format_ris(data)
+    expect(output).to include("TY  - BOOK")
+    expect(output).to include("AU  - Lingard, Zac")
+    expect(output).to include("TI  - The Great Emu War")
+    expect(output).to include("ER  -")
+  end
+end


### PR DESCRIPTION
RIS format has been implemented similarly as the bibtex format. It is a commonly used format for storing reference meta data.

Information on RIS file format can be found on:
> https://en.wikipedia.org/wiki/RIS_(file_format)
